### PR TITLE
ADD: RDF token

### DIFF
--- a/rest_models/backend/auth.py
+++ b/rest_models/backend/auth.py
@@ -49,6 +49,18 @@ class BasicAuth(ApiAuthBase):
         return self.backend(request)
 
 
+
+
+
+
+class RDFToken(ApiAuthBase):
+
+    def __call__(self, request):
+        self.token = self.settings_dict.get('OPTIONS', {}).get('TOKEN', '')
+        request.headers[str('Authorization')] = str("Token %s" % self.token)
+        return request
+    
+    
 class OAuthToken(ApiAuthBase):
 
     @property

--- a/rest_models/backend/compiler.py
+++ b/rest_models/backend/compiler.py
@@ -75,7 +75,7 @@ def get_resource_path(model, pk=None):
     """
     ret = getattr(model.APIMeta, 'resource_path', None) or get_resource_name(model, False)
     if pk is not None:
-        ret += "/%s/" % pk
+        ret += "%s/" % pk
     return ret
 
 


### PR DESCRIPTION
El core apunta a un commit en específico del DjangoRestModels que se usa actualmente en donde justo en ese commit se agregó el RDFToken. Debido a eso, fallaba por temas de auth...